### PR TITLE
GH-24 : Added more asserts in fetch policy overview API

### DIFF
--- a/src/test/java/com/amalvadkar/ihms/common/AbstractIT.java
+++ b/src/test/java/com/amalvadkar/ihms/common/AbstractIT.java
@@ -2,6 +2,7 @@ package com.amalvadkar.ihms.common;
 
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
@@ -9,6 +10,7 @@ import org.springframework.context.annotation.Import;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
+@Tag("it")
 @Import(ContainersConfig.class)
 public abstract class AbstractIT {
 

--- a/src/test/java/com/amalvadkar/ihms/policy/controllers/rest/PolicyOverviewRestControllerTest.java
+++ b/src/test/java/com/amalvadkar/ihms/policy/controllers/rest/PolicyOverviewRestControllerTest.java
@@ -20,6 +20,12 @@ class PolicyOverviewRestControllerTest extends AbstractIT {
                 .post("/api/ihms/policy/fetchpolicyoverview")
                 .then()
                 .body("data", hasSize(2))
+                .body("data[0].policyCategoryId", is(1))
+                .body("data[0].policyCategoryName", is("General"))
+                .body("data[0].policyDocuments", hasSize(2))
+                .body("data[1].policyCategoryId", is(2))
+                .body("data[1].policyCategoryName", is("Providend Fund"))
+                .body("data[1].policyDocuments", hasSize(1))
                 .body("success", is(true))
                 .body("code", is(200))
                 .body("message", is("Fetched Successfully"));


### PR DESCRIPTION
Here we have achived below things

* Added more asserts for fetch policy overview API integration test
* Addded junit tag on integration test so we can run them as configuration as "it" tag to run all integration test and "!it" tag to run all unit test