### PR TITLE
GH - 27 : Changed sonar.login with sonar.token and added no transfer …

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,4 +28,4 @@ jobs:
 
       - if: ${{ github.ref == 'refs/heads/develop' }}
         name: Sonar Scan
-        run: ./mvnw initialize sonar:sonar -Dsonar.login=${{ env.SONAR_TOKEN }}
+        run: ./mvnw --no-transfer-progress initialize sonar:sonar -Dsonar.token=${{ env.SONAR_TOKEN }}


### PR DESCRIPTION
Here we have achieved below things 

* sonar.login property is deprecated that's why changed with new one called sonar.token
* While running sonar scanning also lots of download progress logs are coming that's why added --no-transfer-progress parameter in sonar maven command as well