### PR TITLE
GH-55 : Setup firebase cloud storage as blob storage for system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 
 ### VS Code ###
 .vscode/
+/src/main/resources/firebase.json

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 		<ulid-creator.version>5.2.3</ulid-creator.version>
 		<jsoup.version>1.17.2</jsoup.version>
 		<greenmail-junit5.version>2.0.1</greenmail-junit5.version>
+		<firebase-admin.version>9.2.0</firebase-admin.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -99,6 +100,11 @@
 			<artifactId>greenmail-junit5</artifactId>
 			<version>${greenmail-junit5.version}</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.firebase</groupId>
+			<artifactId>firebase-admin</artifactId>
+			<version>${firebase-admin.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/src/main/java/com/amalvadkar/ihms/AppConfig.java
+++ b/src/main/java/com/amalvadkar/ihms/AppConfig.java
@@ -3,13 +3,19 @@ package com.amalvadkar.ihms;
 import com.amalvadkar.ihms.common.exceptions.ResourceNotFoundException;
 import com.amalvadkar.ihms.holiday.enums.HolidayStatusCodeEnum;
 import com.amalvadkar.ihms.holiday.models.dto.HolidayStatusDTO;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver;
 import org.thymeleaf.templatemode.TemplateMode;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static com.amalvadkar.ihms.common.utils.AppConstants.CODE;
@@ -56,6 +62,21 @@ public class AppConfig {
         emailTemplateResolver.setTemplateMode(TemplateMode.HTML);
         emailTemplateResolver.setCharacterEncoding(StandardCharsets.UTF_8.name());
         return emailTemplateResolver;
+    }
+
+    @Bean("fireBaseStorage")
+    @Profile("!it")
+    public Storage fireBaseStorage() throws IOException {
+        ClassPathResource classPathResource = new ClassPathResource("firebase.json");
+        GoogleCredentials googleCredentials = GoogleCredentials.fromStream(classPathResource.getInputStream());
+        return StorageOptions.newBuilder().setCredentials(googleCredentials).build().getService();
+
+    }
+
+    @Bean("fireBaseStorage")
+    @Profile("it")
+    public Storage fireBaseStorageForIT() {
+        return StorageOptions.newBuilder().build().getService();
     }
 
 }

--- a/src/main/java/com/amalvadkar/ihms/AppConfig.java
+++ b/src/main/java/com/amalvadkar/ihms/AppConfig.java
@@ -73,10 +73,4 @@ public class AppConfig {
 
     }
 
-    @Bean("fireBaseStorage")
-    @Profile("it")
-    public Storage fireBaseStorageForIT() {
-        return StorageOptions.newBuilder().build().getService();
-    }
-
 }

--- a/src/main/java/com/amalvadkar/ihms/ApplicationProperties.java
+++ b/src/main/java/com/amalvadkar/ihms/ApplicationProperties.java
@@ -14,6 +14,14 @@ public record ApplicationProperties(
         @NotEmpty(message = "holidayStatusList property should not be null or empty")
         List<HolidayStatusDTO> holidayStatusList,
         @DefaultValue("false")
-        boolean emailSendEnabled
+        boolean emailSendEnabled,
+        @NotEmpty(message = "bucketName property should not be null or empty")
+        String bucketName,
+        @DefaultValue("7200")
+        Long signedUrlExpiryTimeInSec,
+
+        @DefaultValue("true")
+        boolean blobStorageEnabled
+
 ) {
 }

--- a/src/main/java/com/amalvadkar/ihms/common/helpers/DataBucketHelper.java
+++ b/src/main/java/com/amalvadkar/ihms/common/helpers/DataBucketHelper.java
@@ -1,0 +1,74 @@
+package com.amalvadkar.ihms.common.helpers;
+
+import com.amalvadkar.ihms.ApplicationProperties;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static com.amalvadkar.ihms.common.utils.AppConstants.SLASH;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DataBucketHelper {
+    private static final String FILE_UPLOADED_SUCCESSFULLY_TO_FCS_MSG = "File {} uploaded successfully to FCS on {} path";
+    private static final String SIGNED_URL_GENERATED_SUCCESSFULLY_MSG = "Signed url generated successfully for {} file";
+    public static final String FAILED_TO_GENERATE_SIGN_IN_URL_MSG = "Failed to generate sign in URL for file - {}";
+
+    @Qualifier("fireBaseStorage")
+    private final Storage storage;
+
+    private final ApplicationProperties appProps;
+
+    public void upload(MultipartFile file, String directoryPath, String fileName) {
+        if (blobStorageIsDisabled()){
+            log.warn("Can't upload because blog storage feature is disabled");
+            return;
+        }
+        try {
+            String filePath = directoryPath + SLASH + fileName;
+            BlobId blobId = BlobId.of(appProps.bucketName(), filePath);
+            BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType(file.getContentType()).build();
+            Blob blob = storage.create(blobInfo, file.getBytes());
+            if (nonNull(blob)) {
+                log.info(FILE_UPLOADED_SUCCESSFULLY_TO_FCS_MSG, fileName, filePath);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean blobStorageIsDisabled() {
+        return !appProps.blobStorageEnabled();
+    }
+
+    public String signedUrl(String directoryPath, String fileName) {
+        if (blobStorageIsDisabled()){
+            log.warn("Can't generate signed url because blog storage feature is disabled");
+            return null;
+        }
+        String filePath = directoryPath + SLASH + fileName;
+        BlobId blobId = BlobId.of(appProps.bucketName(), filePath);
+        BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+        URL signedUrl = storage.signUrl(blobInfo, appProps.signedUrlExpiryTimeInSec(), SECONDS);
+        if (isNull(signedUrl)) {
+            log.info(FAILED_TO_GENERATE_SIGN_IN_URL_MSG, filePath);
+            return null;
+        }
+        log.info(SIGNED_URL_GENERATED_SUCCESSFULLY_MSG, filePath);
+        return signedUrl.toString();
+    }
+
+}

--- a/src/main/java/com/amalvadkar/ihms/common/utils/AppConstants.java
+++ b/src/main/java/com/amalvadkar/ihms/common/utils/AppConstants.java
@@ -17,6 +17,7 @@ public class AppConstants {
     public static final String FEEDBACK_STATUS = "feedbackStatus";
     public static final String EMAIL_SUBJECT_FEEDBACK_ADDED_SUCCESSFULLY = "Feedback Added Successfully";
     public static final String CREATE_FEEDBACK_SUCCESS_EMAIL_TEMPLATE_NAME = "create-feedback-success-email";
+    public static final String SLASH = "/";
 
     private AppConstants(){
         throw new IllegalStateException("You can't create object for AppConstants utility class");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,5 @@ ihms:
     - title: "Has Gone"
       colorCode: "#FF0000"
       code: HG
+  bucket-name: ${BUCKET_NAME}
+  signed-url-expiry-timeIn-sec: 3600

--- a/src/test/java/com/amalvadkar/ihms/TestConfig.java
+++ b/src/test/java/com/amalvadkar/ihms/TestConfig.java
@@ -1,0 +1,19 @@
+package com.amalvadkar.ihms;
+
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+@Slf4j
+public class TestConfig {
+
+    @Bean("fireBaseStorage")
+    public Storage fireBaseStorage() {
+        log.info("Creating storage object for test env");
+        return StorageOptions.newBuilder().build().getService();
+    }
+
+}

--- a/src/test/java/com/amalvadkar/ihms/common/AbstractIT.java
+++ b/src/test/java/com/amalvadkar/ihms/common/AbstractIT.java
@@ -1,5 +1,6 @@
 package com.amalvadkar.ihms.common;
 
+import com.amalvadkar.ihms.TestConfig;
 import com.icegreen.greenmail.configuration.GreenMailConfiguration;
 import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.ServerSetupTest;
@@ -16,7 +17,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @Tag("it")
-@Import(ContainersConfig.class)
+@Import({ContainersConfig.class , TestConfig.class})
 @ActiveProfiles("it")
 public abstract class AbstractIT {
 

--- a/src/test/resources/application-it.yml
+++ b/src/test/resources/application-it.yml
@@ -8,3 +8,4 @@ spring:
 
 ihms:
   email-send-enabled: true
+  blobStorageEnabled: false


### PR DESCRIPTION
Here we have achieved below things 

* Setup firebase cloud storage configuration 
* Implemented logic  to upload and get signed url from firebase could storage ( FCS )
* Create blob storage implementation as feature flag
* Created simple and dummy storage object if profile is "it"  in test configuration so Storage object will be create as spring bean and other integration test will not fail
* Made blob storage feature disable in integration test ( "it" profile )

Closes #55 